### PR TITLE
Add extension to unzip the relevant binary upon gem installation

### DIFF
--- a/ext/wkhtmltopdf-binary/Rakefile
+++ b/ext/wkhtmltopdf-binary/Rakefile
@@ -1,0 +1,68 @@
+# This code is copied almost entirely from `bin/wkhtmltopdf`. If we don't
+# address this duplication, upstream changes to that file should be manually
+# ported here.
+
+###
+# wkhtmltopdf_binary_gem Copyright 2013 The University of Iowa
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+require 'rbconfig'
+require 'zlib'
+
+suffix = case RbConfig::CONFIG['host_os']
+         when /linux/
+           os = `. /etc/os-release 2> /dev/null && echo ${ID}_${VERSION_ID}`.strip
+
+           os_based_on_ubuntu_16_04 = os.start_with?('ubuntu_16.') || os.start_with?('ubuntu_17.')
+           os = 'ubuntu_16.04' if os_based_on_ubuntu_16_04
+
+           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('ubuntu_19.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop') || os.start_with?('zorin')
+           os = 'ubuntu_18.04' if os_based_on_ubuntu_18_04
+
+           os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')
+           os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
+
+           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && !os.start_with?('amzn_2'))
+           os = 'centos_6' if os_based_on_centos_6
+
+           os_based_on_centos_7 = os.start_with?('amzn_2')
+           os = 'centos_7' if os_based_on_centos_7
+
+           os_based_on_debian_9 = (/(debian_9|deepin)/ =~ os)
+           os = 'debian_9' if os_based_on_debian_9
+
+           os_based_on_debian = !os_based_on_debian_9 && os.start_with?('debian')
+           os = 'debian_10' if os_based_on_debian
+
+           os_based_on_archlinux = os.start_with?('arch_') || os.start_with?('manjaro_')
+           os = 'archlinux' if os_based_on_archlinux
+
+           architecture = RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'amd64' : 'i386'
+
+           "#{os}_#{architecture}"
+         when /darwin/
+           'macos_cocoa'
+         else
+           'unknown'
+         end
+
+suffix = ENV['WKHTMLTOPDF_HOST_SUFFIX'] unless ENV['WKHTMLTOPDF_HOST_SUFFIX'].to_s.empty?
+
+binary = "#{File.expand_path('../../bin/wkhtmltopdf', __dir__)}_#{suffix}"
+
+task :default do
+  if File.exist?("#{binary}.gz") && !File.exist?(binary)
+    File.open binary, 'wb', 0o755 do |file|
+      Zlib::GzipReader.open("#{binary}.gz") { |gzip| file << gzip.read }
+    end
+  end
+
+  unless File.exist? binary
+    raise 'Invalid platform, must be running on Ubuntu 20.04 ' \
+          'CentOS 7, Amazon Linux 2, Debian 9 x64, or intel-based Cocoa macOS ' \
+          "(missing binary: #{binary})."
+  end
+end

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -12,5 +12,7 @@ Gem::Specification.new do |s|
   s.executables << "wkhtmltopdf"
   s.require_path = '.'
 
+  s.extensions = ['ext/wkhtmltopdf-binary/Rakefile']
+
   s.add_development_dependency "minitest"
 end


### PR DESCRIPTION
This will run the code to detect and unzip the relevant binary when the gem is installed, so that we won't have to unzip it at runtime the first time `wkhtmltopdf` is invoked. This is particularly useful because it avoids potential concurrency issues when running multiple threads that use `wkhtmltopdf` at the same time, which could result in `Text file busy (Errno::ETXTBSY)` errors if the threads simultaneously attempt to unzip the wkhtmltopdf binary. (If we ensure the binary is unzipped at gem installation time, the threads won't have to unzip it at runtime, effectively bypassing this issue.)

This is the alternate approach to #3 that I mentioned in https://github.com/mycase/wkhtmltopdf-binary/pull/3#discussion_r606098043.

---

Note: This could make `bundle install` throw an error when it's executed on new operating systems for which we don't package a corresponding `wkhtmltopdf` executable. That's typically desirable, but in cases where we just want to test something out and we don't care if `wkhtmltopdf` is broken (since most of our application still works fine without it), we can set the [`WKHTMLTOPDF_HOST_SUFFIX` environment variable](https://github.com/mycase/wkhtmltopdf-binary/blob/7b4c82de8981250910bb9c12c410ff33f9938073/ext/wkhtmltopdf-binary/Rakefile#L52) to allow bundle install to succeed. For example `WKHTMLTOPDF_HOST_SUFFIX=ubuntu_20.04_amd64 bundle install` would succeed even on non-Ubuntu 20.04-systems (it'd just unzip a `wkhtmltopdf` binary which may not work on that system).