### PR TITLE
Add back Ubuntu 18.04 support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# 0.12.6.5.slim5 (published to https://rubygems.pkg.github.com/mycase)
+
+* Add binary to support Ubuntu 18.04 on amd64
+* Remove support for Debian 9
+
 # 0.12.6.5.slim4 (published to https://rubygems.pkg.github.com/mycase)
 
 Add binary to support alpine linux (this still requires `apk add wkthmltopdf`

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -66,7 +66,7 @@ if File.exist?("#{binary}.gz") && !File.exist?(binary)
 end
 
 unless File.exist? binary
-  raise 'Invalid platform, must be running on Ubuntu 20.04 ' \
+  raise 'Invalid platform, must be running on Ubuntu 18.04/20.04 ' \
         'CentOS 7, Amazon Linux 2, Debian 9 x64, or intel-based Cocoa macOS ' \
         "(missing binary: #{binary})."
 end

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -67,7 +67,7 @@ end
 
 unless File.exist? binary
   raise 'Invalid platform, must be running on Ubuntu 18.04/20.04 ' \
-        'CentOS 7, Amazon Linux 2, Debian 9 x64, or intel-based Cocoa macOS ' \
+        'CentOS 7, Amazon Linux 2, or intel-based Cocoa macOS ' \
         "(missing binary: #{binary})."
 end
 

--- a/ext/wkhtmltopdf-binary/Rakefile
+++ b/ext/wkhtmltopdf-binary/Rakefile
@@ -69,8 +69,8 @@ task :default do
   end
 
   unless File.exist? binary
-    raise 'Invalid platform, must be running on Ubuntu 20.04 ' \
-          'CentOS 7, Amazon Linux 2, Debian 9 x64, or intel-based Cocoa macOS ' \
+    raise 'Invalid platform, must be running on Ubuntu 18.04/20.04 ' \
+          'CentOS 7, Amazon Linux 2, or intel-based Cocoa macOS ' \
           "(missing binary: #{binary})."
   end
 end

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.5.slim4"
+  s.version = "0.12.6.5.slim5"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
...and drop support for Debian 9.

This is to support a Ruby upgrade on MyCase App.

MyCase App uses the old-style `circleci/ruby:2.6.1` image, which is based on Debian 9. Upgrading to `circleci/ruby:2.6.6` would mean upgrading to Debian 10, which isn't supported by this gem right now. But using Debian on CI is silly anyway and we want to migrate to CircleCI's new `cimg` images eventually, too, so it seems more natural for us to migrate to `cimg/ruby:2.6.6` now. That's based on Ubuntu 18.04.

According to a [CircleCI announcement](https://discuss.circleci.com/t/ubuntu-20-04-next-gen-convenience-images/36604), newer versions of the `cimg/ruby` image will be based on Ubuntu 20.04 which is of course what we want longer-term. Running CI on Ubuntu 18.04 in the interim means we'll get CI closer to production and will unblock the 2.6.6 upgrade for now.