### PR TITLE
Add support for Ubuntu 22.04

### DIFF
--- a/.docker/Dockerfile-ubuntu_22.04
+++ b/.docker/Dockerfile-ubuntu_22.04
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y ruby libjpeg8 libxrender1 libfontconfig1
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/wkhtmltopdf_macos_cocoa
 bin/wkhtmltopdf_ubuntu_16.04_amd64
 bin/wkhtmltopdf_ubuntu_18.04_amd64
 bin/wkhtmltopdf_ubuntu_20.04_amd64
+bin/wkhtmltopdf_ubuntu_22.04_amd64
 bin/wkhtmltopdf_centos_6_i386
 bin/wkhtmltopdf_centos_7_i386
 bin/wkhtmltopdf_debian_9_i386

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,10 @@ wkhtmltopdf_debian_9_i386.gz, wkhtmltopdf_ubuntu_16.04_amd64.gz,
 wkhtmltopdf_ubuntu_16.04_i386.gz, wkhtmltopdf_ubuntu_18.04_amd64.gz,
 wkhtmltopdf_ubuntu_18.04_i386.gz
 
+# 0.12.6.6
+
+Add support for Ubuntu 22.04
+
 # 0.12.6.5
 
 Fix ability to use on Debian 9 systems

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -23,8 +23,10 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')
            os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
 
-           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && !os.start_with?('amzn_2'))
-           os = 'centos_6' if os_based_on_centos_6
+           os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.')
+
+           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||
+                              (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
 
            os_based_on_centos_7 = os.start_with?('amzn_2')
            os = 'centos_7' if os_based_on_centos_7
@@ -66,7 +68,7 @@ if File.exist?("#{binary}.gz") && !File.exist?(binary)
 end
 
 unless File.exist? binary
-  raise 'Invalid platform, must be running on Ubuntu 18.04/20.04 ' \
+  raise 'Invalid platform, must be running on Ubuntu 18.04/20.04/22.04, ' \
         'CentOS 7, Amazon Linux 2, or intel-based Cocoa macOS ' \
         "(missing binary: #{binary})."
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 
+  ubuntu_22.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_22.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
   debian_9:
     build:
       context: .

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -38,6 +38,10 @@ class WithDockerTest < Minitest::Test
     test with: 'ubuntu_20.04'
   end
 
+  def test_with_ubuntu_22
+   test with: 'ubuntu_22.04'
+  end
+
   def test_with_archlinux
     test with: 'archlinux'
   end

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.5.slim5"
+  s.version = "0.12.6.5.slim5b"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.5.slim5b"
+  s.version = "0.12.6.6.slim6"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
Add support for Ubuntu 22.04 (https://github.com/zakird/wkhtmltopdf_binary_gem/pull/150)

This is needed for upgrading to Ruby 3.2.0 as `cimg/ruby-3.2.0` uses Ubuntu 22.0.4